### PR TITLE
Draw other people's cursor's behind CodeMirror surface.

### DIFF
--- a/lib/codemirror-adapter.js
+++ b/lib/codemirror-adapter.js
@@ -224,6 +224,7 @@ ot.CodeMirrorAdapter = (function () {
       cursorEl.style.borderLeftColor = color;
       cursorEl.style.height = (cursorCoords.bottom - cursorCoords.top) * 0.9 + 'px';
       cursorEl.style.marginTop = (cursorCoords.top - cursorCoords.bottom) + 'px';
+      cursorEl.style.zIndex = -1;
       cursorEl.setAttribute('data-clientid', clientId);
       this.cm.addWidget(cursorPos, cursorEl, false);
       return {


### PR DESCRIPTION
Set z-index of other cursors to -1 so they don't interfere with codemirror's click handlers.  Without this, if you click on/around somebody else's cursor your cursor won't move since the click is going to the pre element instead of to CodeMirror.
