### PR TITLE
Draw other people's cursors behind CodeMirror.

### DIFF
--- a/lib/codemirror-adapter.js
+++ b/lib/codemirror-adapter.js
@@ -224,6 +224,7 @@ ot.CodeMirrorAdapter = (function () {
       cursorEl.style.borderLeftColor = color;
       cursorEl.style.height = (cursorCoords.bottom - cursorCoords.top) * 0.9 + 'px';
       cursorEl.style.marginTop = (cursorCoords.top - cursorCoords.bottom) + 'px';
+      cursorEl.style.zIndex = 0;
       cursorEl.setAttribute('data-clientid', clientId);
       this.cm.addWidget(cursorPos, cursorEl, false);
       return {


### PR DESCRIPTION
Attempt #2.  Looks like CodeMirror's z-indexes changed recently.  Setting the cursorEl's z-index to 0 now makes it visible, but not interfere with clicks.
