### PR TITLE
Support socket.io <= 0.9 and socket.io >= 1.0

### DIFF
--- a/lib/editor-socketio-server.js
+++ b/lib/editor-socketio-server.js
@@ -57,7 +57,10 @@ EditorSocketIOServer.prototype.addClient = function (socket) {
       console.log("Disconnect");
       socket.leave(self.docId);
       self.onDisconnect(socket);
-      if (socket.manager.sockets.clients(self.docId).length === 0) {
+      if (
+        (socket.manager && socket.manager.sockets.clients(self.docId).length === 0) || // socket.io <= 0.9
+        (socket.ns && Object.keys(socket.ns.connected).length === 0) // socket.io >= 1.0
+      ) {
         self.emit('empty-room');
       }
     });


### PR DESCRIPTION
`lib/editor-socketio-server.js` depended on an API removed in socket.io 1.0 and beyond. This change adds compatibility to both <= 0.9 and >= 1.0